### PR TITLE
Update preferences.c

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -518,7 +518,11 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   else
   {
     //load default text
-    gtk_text_buffer_set_text(buffer, _("/* Enter CSS theme tweaks here */\n\n"), -1);
+    gtk_text_buffer_set_text(buffer, _("/* Enter CSS theme tweaks here */\n\n"
+                                       "// workaround for missing cursor on Windows 10, uncomment below to enable\n"
+                                       "// {\n"
+                                       "//   font-family: sans;\n"
+                                       "// }\n\n"), -1);
   }
 
 }


### PR DESCRIPTION
Add Windows 10 cursor workaround to default css tweaks in commented out form

See issue #7615